### PR TITLE
This PR fixes 5 issues thanks to snyk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 openjdk:11.0.16-jdk-slim-bullseye
+FROM --platform=linux/amd64 openjdk:25-jdk-slim-bullseye
 #FROM --platform=linux/amd64 openjdk:21-slim-bullseye
 
 RUN addgroup --system javauser && adduser --system --home /home/javauser --ingroup javauser javauser


### PR DESCRIPTION
It updates openjdk from version 11.0.16-jdk-slim-bullseye to version 25-jdk-slim-bullseye.
Review relevant docs for possible breaking changes.


To find more details, see the Snyk project [tdmidas&#x2F;snyk-boot-web:Dockerfile](https:&#x2F;&#x2F;app.snyk.io&#x2F;org&#x2F;tdmidas&#x2F;project&#x2F;2dff49cd-2532-4077-9a59-537a820b0ecf?utm_source&#x3D;github&amp;utm_medium&#x3D;referral&amp;page&#x3D;fix-pr)


[//]: # 'snyk:metadata:{"customTemplate":{"variablesUsed":["issue_count","package_name","package_from","package_to","snyk_project_name","snyk_project_url"],"fieldsUsed":["commitMessage","description","title"]},"dependencies":[{"name":"openjdk","from":"11.0.16-jdk-slim-bullseye","to":"25-jdk-slim-bullseye"}],"env":"prod","issuesToFix":["SNYK-DEBIAN11-GLIBC-5927133","SNYK-DEBIAN11-GLIBC-5927133","SNYK-DEBIAN11-KRB5-7411316","SNYK-DEBIAN11-KRB5-7411316","SNYK-DEBIAN11-KRB5-7411316"],"prId":"55add252-8d3a-49f2-97b5-e0c23db439ab","prPublicId":"55add252-8d3a-49f2-97b5-e0c23db439ab","packageManager":"dockerfile","priorityScoreList":[829,714],"projectPublicId":"2dff49cd-2532-4077-9a59-537a820b0ecf","projectUrl":"https://app.snyk.io/org/tdmidas/project/2dff49cd-2532-4077-9a59-537a820b0ecf?utm_source=github&utm_medium=referral&page=fix-pr","prType":"fix","templateFieldSources":{"branchName":"default","commitMessage":"repository","description":"repository","title":"repository"},"templateVariants":["custom","updated-fix-title","priorityScore"],"type":"user-initiated","upgrade":["SNYK-DEBIAN11-GLIBC-5927133","SNYK-DEBIAN11-GLIBC-5927133","SNYK-DEBIAN11-KRB5-7411316","SNYK-DEBIAN11-KRB5-7411316","SNYK-DEBIAN11-KRB5-7411316"],"vulns":["SNYK-DEBIAN11-GLIBC-5927133","SNYK-DEBIAN11-KRB5-7411316"],"patch":[],"isBreakingChange":false,"remediationStrategy":"vuln"}'